### PR TITLE
Fix for bug: https://github.com/tmssoftware/smartsetup/issues/5

### DIFF
--- a/tmsgui/src/Forms.Credentials.dfm
+++ b/tmsgui/src/Forms.Credentials.dfm
@@ -3,7 +3,7 @@ object CredentialsForm: TCredentialsForm
   Top = 0
   BorderStyle = bsDialog
   Caption = 'Enter credentials'
-  ClientHeight = 173
+  ClientHeight = 231
   ClientWidth = 258
   Color = clBtnFace
   Font.Charset = DEFAULT_CHARSET
@@ -14,11 +14,11 @@ object CredentialsForm: TCredentialsForm
   Position = poMainFormCenter
   DesignSize = (
     258
-    173)
+    231)
   TextHeight = 15
   object lbInvalidCredentials: TLabel
     Left = 16
-    Top = 112
+    Top = 160
     Width = 95
     Height = 15
     Caption = 'Invalid credentials'
@@ -29,15 +29,24 @@ object CredentialsForm: TCredentialsForm
     Font.Style = []
     ParentFont = False
   end
+  object Label1: TLabel
+    Left = 15
+    Top = 16
+    Width = 224
+    Height = 33
+    AutoSize = False
+    Caption = 'Credentials are not required for third-party products.'
+    WordWrap = True
+  end
   object edEmail: TLabeledEdit
     Left = 16
-    Top = 32
+    Top = 80
     Width = 223
     Height = 23
     Anchors = [akLeft, akTop, akRight]
     EditLabel.Width = 34
     EditLabel.Height = 15
-    EditLabel.Caption = 'E-mail'
+    EditLabel.Caption = '&E-mail'
     Font.Charset = DEFAULT_CHARSET
     Font.Color = clWindowText
     Font.Height = -12
@@ -49,13 +58,13 @@ object CredentialsForm: TCredentialsForm
   end
   object edCode: TLabeledEdit
     Left = 16
-    Top = 80
+    Top = 131
     Width = 223
     Height = 23
     Anchors = [akLeft, akTop, akRight]
     EditLabel.Width = 28
     EditLabel.Height = 15
-    EditLabel.Caption = 'Code'
+    EditLabel.Caption = '&Code'
     Font.Charset = DEFAULT_CHARSET
     Font.Color = clWindowText
     Font.Height = -12
@@ -68,24 +77,28 @@ object CredentialsForm: TCredentialsForm
   end
   object btOk: TButton
     Left = 83
-    Top = 137
+    Top = 195
     Width = 75
     Height = 25
-    Anchors = [akTop, akRight]
+    Anchors = [akRight, akBottom]
     Caption = 'Ok'
     Default = True
     TabOrder = 2
     OnClick = btOkClick
+    ExplicitLeft = 81
+    ExplicitTop = 137
   end
   object btCancel: TButton
     Left = 164
-    Top = 137
+    Top = 195
     Width = 75
     Height = 25
-    Anchors = [akTop, akRight]
+    Anchors = [akRight, akBottom]
     Cancel = True
-    Caption = 'Cancel'
+    Caption = '&Skip'
     ModalResult = 2
     TabOrder = 3
+    ExplicitLeft = 162
+    ExplicitTop = 137
   end
 end

--- a/tmsgui/src/Forms.Credentials.pas
+++ b/tmsgui/src/Forms.Credentials.pas
@@ -13,6 +13,7 @@ type
     btOk: TButton;
     btCancel: TButton;
     lbInvalidCredentials: TLabel;
+    Label1: TLabel;
     procedure btOkClick(Sender: TObject);
   private
     { Private declarations }


### PR DESCRIPTION
Improvements:
1) Rename "cancel" button to "Skip"
2) Add label saying "credentials are not required for third-party products" 3) Added keyboard shortcuts for "E-Maill" and "Credentials".